### PR TITLE
Fix CTA field and divider keys

### DIFF
--- a/src/components/CTASection.tsx
+++ b/src/components/CTASection.tsx
@@ -4,7 +4,7 @@ import { ArrowRight, Shield, Clock, Zap } from 'lucide-react';
 const CTASection: React.FC = () => {
   const [formData, setFormData] = useState({
     name: '',
-    whatsapp: '',
+    whatsApp: '',
     company: '',
     pain: ''
   });
@@ -49,7 +49,7 @@ const CTASection: React.FC = () => {
     setIsSubmitting(false);
     
     // Reset form and show success message
-    setFormData({ name: '', whatsapp: '', company: '', pain: '' });
+    setFormData({ name: '', whatsApp: '', company: '', pain: '' });
     alert('Sucesso! Entraremos em contato em até 2 horas.');
   };
 
@@ -125,8 +125,8 @@ const CTASection: React.FC = () => {
                   </label>
                   <input
                     type="tel"
-                    name="whatsapp"
-                    value={formData.whatsapp}
+                    name="whatsApp"
+                    value={formData.whatsApp}
                     onChange={handleInputChange}
                     required
                     className="w-full bg-white/10 border-2 border-white/20 rounded-xl px-4 sm:px-6 py-3 sm:py-4 text-white text-base sm:text-lg focus:border-[#FF7A00] focus:outline-none transition-colors duration-300 backdrop-blur-md placeholder-gray-400"

--- a/src/components/dashboard/DashboardLayout.tsx
+++ b/src/components/dashboard/DashboardLayout.tsx
@@ -108,9 +108,9 @@ const DashboardLayout: React.FC<DashboardLayoutProps> = ({ children, currentPage
             </button>
           </div>
           <nav className="flex-1 overflow-y-auto p-4 space-y-2">
-            {navigation.map((item) => {
+            {navigation.map((item, index) => {
               if (item.name === '---') {
-                return <div key={item.href} className="h-px bg-white/10 my-4"></div>;
+                return <div key={`divider-${index}`} className="h-px bg-white/10 my-4"></div>;
               }
               
               return (
@@ -142,9 +142,9 @@ const DashboardLayout: React.FC<DashboardLayoutProps> = ({ children, currentPage
             <span className="text-xl font-bold text-white">meusuper.app</span>
           </div>
           <nav className="flex-1 overflow-y-auto p-6 space-y-2">
-            {navigation.map((item) => {
+            {navigation.map((item, index) => {
               if (item.name === '---') {
-                return <div key={item.href} className="h-px bg-white/10 my-4"></div>;
+                return <div key={`divider-${index}`} className="h-px bg-white/10 my-4"></div>;
               }
               
               return (

--- a/src/components/dashboard/LogsPage.tsx
+++ b/src/components/dashboard/LogsPage.tsx
@@ -139,7 +139,7 @@ const LogsPage: React.FC = () => {
   const loadLogs = async () => {
     setIsLoading(true);
     
-    // Simulate API call with realistic AI sales data
+    // Simulate API request and load mock log data
     await new Promise(resolve => setTimeout(resolve, 1000));
     
     const mockLogs: LogEntry[] = [


### PR DESCRIPTION
## Summary
- update WhatsApp property name in CTA form
- use unique keys for divider items in dashboard layout
- clarify comment about mock logs

## Testing
- `npm run lint` *(fails: many existing lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68621120566c8324a5c9d6b6d220a226