### PR TITLE
Fix Pause not defined error on automation page

### DIFF
--- a/src/components/dashboard/AutomationPage.tsx
+++ b/src/components/dashboard/AutomationPage.tsx
@@ -1,7 +1,8 @@
 import React, { useState, useRef, useCallback, useEffect } from 'react';
 import { 
-  Plus, 
-  Play, 
+  Plus,
+  Play,
+  Pause,
   Save, 
   Download, 
   Upload, 


### PR DESCRIPTION
## Summary
- fix missing `Pause` import in `AutomationPage` to avoid runtime reference error

## Testing
- `npm run lint` *(fails: 331 problems)*
- `npm test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_686297e0465883249b132c444d3b7fbd